### PR TITLE
Set deployment target for OS X static lib.

### DIFF
--- a/build_macosx/Framework.xcodeproj/project.pbxproj
+++ b/build_macosx/Framework.xcodeproj/project.pbxproj
@@ -699,13 +699,17 @@
 		1DEB91F008733DB70010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
 		1DEB91F108733DB70010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This quiets a lot of linking warnings in regards to linking against different OS X deployment targets. 