### PR TITLE
use XDG_* paths if they're set

### DIFF
--- a/src/PathUtils.cpp
+++ b/src/PathUtils.cpp
@@ -125,6 +125,10 @@ fs::path PathUtils::GetAppResourcesPath()
 	{
 		return fs::path(getenv("APPDIR")) / "usr/share";
 	}
+	if(getenv("XDG_DATA_HOME"))
+	{
+		return fs::path(getenv("XDG_DATA_HOME"));
+	}
 	return fs::path(getenv("HOME")) / ".local/share";
 }
 
@@ -135,11 +139,19 @@ fs::path PathUtils::GetRoamingDataPath()
 
 fs::path PathUtils::GetPersonalDataPath()
 {
+	if(getenv("XDG_CONFIG_HOME"))
+	{
+		return fs::path(getenv("XDG_CONFIG_HOME"));
+	}
 	return fs::path(getenv("HOME")) / ".local/share";
 }
 
 fs::path PathUtils::GetCachePath()
 {
+	if(getenv("XDG_CACHE_HOME"))
+	{
+		return fs::path(getenv("XDG_CACHE_HOME"));
+	}
 	return fs::path(getenv("HOME")) / ".cache";
 }
 


### PR DESCRIPTION
when used on `Play-`'s side within flatpak the paths used end up looking like 

`~/.var/app/org.purei.play/data/Play Data Files/`
`~/.var/app/org.purei.play/cache/Play Data Files/`
`~/.var/app/org.purei.play/config/Play Data Files/`

while odd, Its not an issue (unless you try to traverse the home path (`GetPersonalDataPath()`) to get to the cache directory which shouldnt happen anyway.

Notes: `XDG_DATA_HOME` is not strickly correct, im trying to find if we can package `states.db` with the package...
though for that to happen anyway, we would need to have `states.db` on git, as I've read that flathub build process is done offline. (though we can probably push it to the flathub repo, not ours)

related to https://github.com/jpd002/Play-/issues/1189
https://github.com/jpd002/Play-/pull/1180
https://github.com/jpd002/Play-/issues/1122

edit:
ummm we can access the `share` folder (which stores the `states.db` using `/app/share/`)
edit 2: note there are few references to `/app/share` in flatpak site which is what im going with https://docs.flatpak.org/en/latest/freedesktop-quick-reference.html