### PR TITLE
check and use  as app resource path, if it exist

### DIFF
--- a/src/PathUtils.cpp
+++ b/src/PathUtils.cpp
@@ -125,9 +125,13 @@ fs::path PathUtils::GetAppResourcesPath()
 	{
 		return fs::path(getenv("APPDIR")) / "usr/share";
 	}
-	if(getenv("XDG_DATA_HOME"))
+
+	auto path = fs::path("/app/share");
+	std::error_code existsErrorCode;
+	bool exists = fs::exists(path, existsErrorCode);
+	if(!existsErrorCode && exists)
 	{
-		return fs::path(getenv("XDG_DATA_HOME"));
+		return path;
 	}
 	return fs::path(getenv("HOME")) / ".local/share";
 }


### PR DESCRIPTION
related to #34 

apologies, I thought I pushed this out with the previous PR.

I also find another [reference](https://github.com/flatpak/flatpak-builder/blob/main/tests/test.yaml), the sample build config, they also use the `/app` directory.