### PR TITLE
undefine None

### DIFF
--- a/include/opengl/OpenGlDef.h
+++ b/include/opengl/OpenGlDef.h
@@ -42,6 +42,8 @@
 #elif defined(GLES_COMPATIBILITY)
 #include <EGL/egl.h>
 #include <GLES3/gl3.h>
+// egl can reference Xlib.h->X.h which defines None, which causes issues with qt (qgroupaction) down the line for using None in enum
+#undef None
 #endif
 
 #elif defined(__EMSCRIPTEN__)


### PR DESCRIPTION
related to https://github.com/jpd002/Play-/issues/1148 and currently an issue when building flatpak aarch64 package https://flathub.org/builds/#/builders/11/builds/6575/steps/6/logs/stdio

egl can reference Xlib.h->X.h which defines None, which causes issues with qt (qgroupaction) down the line for using None in enum