### PR TITLE
Update Loader.cpp for macOS/iOS frameworks

### DIFF
--- a/src/vulkan/Loader.cpp
+++ b/src/vulkan/Loader.cpp
@@ -76,6 +76,8 @@ void CLoader::LoadLibrary()
 #ifdef __APPLE__
 	libPaths.push_back("@executable_path/../Resources/libMoltenVK.dylib");
 	libPaths.push_back("@executable_path/libMoltenVK.dylib");
+	libPaths.push_back("@executable_path/Frameworks/MoltenVK.framework/MoltenVK");
+	libPaths.push_back("@executable_path/Contents/Frameworks/MoltenVK.framework/MoltenVK");
 #else
 	libPaths.push_back("libvulkan.so");
 	libPaths.push_back("libvulkan.so.1");


### PR DESCRIPTION
This adds the Frameworks paths for both iOS and macOS app bundles when using MoltenVK from a framework or .xcframework in XCode.